### PR TITLE
Add the offical neo4j-go-driver in the bolt connectors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Maintained by Neo4j Developer Relations.
 
 ### Bolt
 
+* [neo4j-go-driver](https://github.com/neo4j/neo4j-go-driver) - Go driver for Neo4j binary protocol.
 * [neo4j-java-driver](https://github.com/neo4j/neo4j-java-driver) - Java driver for Neo4j binary protocol.
 * [neo4j-python-driver](https://github.com/neo4j/neo4j-python-driver) - Python driver for Neo4j binary protocol.
 * [neo4j-javascript-driver](https://github.com/neo4j/neo4j-javascript-driver) - JavaScript driver for Neo4j binary protocol.


### PR DESCRIPTION
Add link to the official `neo4j-go-driver` implemented and supported by the neo4j team. Also it works with the latest version of Neo4j.